### PR TITLE
FINT-471: Shopify version update 2025-10

### DIFF
--- a/lib/api/ApiClient.php
+++ b/lib/api/ApiClient.php
@@ -27,7 +27,7 @@ final class ApiClient {
 	/**
 	 * @var string The Graphql version to be used
 	 */
-	const GRAPHQL_VERSION = '2025-01';
+	const GRAPHQL_VERSION = '2025-10';
 
 	/**
 	 * @var ?string Store for the shop code

--- a/lib/connectors/shopify/pullers/BulkProducts.php
+++ b/lib/connectors/shopify/pullers/BulkProducts.php
@@ -67,7 +67,6 @@ class BulkProducts extends BulkBase
 			'product', # product_id
 			'sku',
 			'taxable',
-			'taxCode', # tax_code
 			'title',
 			'updatedAt', # updated_at
 			'weight', # (weight_unit now a part of this field)
@@ -246,6 +245,11 @@ class BulkProducts extends BulkBase
 				}
 			}
 			GQL;
+
+		//variant.taxCode is deprecated as of version 2025-10
+		//https://shopify.dev/changelog/deprecation-of-tax-code-field
+		//https://shopify.dev/docs/api/admin-graphql/latest/objects/ProductVariant#field-ProductVariant.fields.taxCode
+		
 	}
 
 	/**


### PR DESCRIPTION
Mark 'taxCode' field from BulkProducts as deprecated

Removed deprecated 'taxCode' field from product attributes and added deprecation notice.